### PR TITLE
Added the .b extension

### DIFF
--- a/grammars/brainfuck.cson
+++ b/grammars/brainfuck.cson
@@ -2,6 +2,7 @@
 'fileTypes': [
   'bf'
   'brainfuck'
+  'b'
 ]
 'name': 'Brainfuck'
 'patterns': [


### PR DESCRIPTION
According to https://esolangs.org/wiki/Brainfuck, .b is the correct
extension for brainfuck code. The .bf extension is used quite a lot for
brainfuck code but actually should be used for Befunge code instead.
I’ve left it in because a lot of programmers use .bf for brainfuck.